### PR TITLE
Separate rank and crown datasets

### DIFF
--- a/mhcc/maintenance_fns.js
+++ b/mhcc/maintenance_fns.js
@@ -533,3 +533,232 @@ function arrayTranspose_(oldArr)
   }
   return newArr;
 }
+/** Function that takes the 12-column Crowns table and exports rank data, operating on sets of users at a time.
+ * 
+ */
+function populateRankFusionTable_()
+{
+  /**
+   * Obtain the UIDs of those members that have data in the Rank DB FusionTable.
+   * @return {String[]}
+   */
+  function _getRankTableUserIDs_()
+  {
+    var sql = "SELECT UID FROM " + rankTableId + " GROUP BY UID ORDER BY UID ASC";
+    var resp = FusionTables.Query.sqlGet(sql, { quotaUser: "maintenance" });
+    if (!resp || !resp.rows || !resp.columns)
+      return [];
+    return (resp.rows.map(function (row) { return String(row[0]); }));
+  }
+  /**
+   * Query the Crown FusionTable to determine how many rows each member has, and return a UID-indexed object.
+   * 
+   * @return {{uid:Number}}
+   */
+  function _getCrownTableRowCounts_()
+  {
+    var sql = "SELECT UID, Count(LastTouched) FROM " + ftid + " GROUP BY UID";
+    var resp = FusionTables.Query.sqlGet(sql, { quotaUser: "maintenance" });
+    var output = {};
+    resp.rows.forEach(function (row) { output[String(row[0])] = row[1] * 1; });
+    return output;
+  }
+  /**
+   * Return an array of the next set of UIDs to query for migratable records. Makes sure that both the query string length
+   * and number of rows queried will be below the supplied arguments.
+   * Mutates the input "remaining" array.
+   * 
+   * @param {String[][]} remaining MUTABLE 2D array of [Name, UID] of members that have yet to be migrated.
+   * @param {{uid:Number}} rowKey  Lookup object which stores the number of rows a given UID adds to the overall query.
+   * @param {Number} maxRows       The maximum number of rows that should return from a query (i.e. to not generate a "Response > 10 MB" 503 error).
+   * @param {Number} maxUIDStrLength The maximum joined length of the queried UIDs (total query string length must be < ~8050 characters).
+   * @return {String[]}
+   */
+  function _getNextUserSet_(remaining, rowKey, maxRows, maxUIDStrLength)
+  {
+    if (!remaining || !remaining.length)
+      return [];
+    if (!maxUIDStrLength) maxUIDStrLength = 7900;
+    const unknown = remaining.filter(function (memUID) { return (!rowKey[memUID[1]] && rowKey[memUID[1]] !== 0); });
+    if (unknown.length)
+    {
+      console.warn({ "no-row members": unknown });
+      throw new Error("Some members not present in the row key");
+    }
+
+    // Require the "remaining" set is sorted descending by number of rows.
+    remaining.sort(function (a, b) { return rowKey[b[1]] - rowKey[a[1]]; });
+
+    const nextSet = [];
+    var nextRows = 0, queryLength = 0;
+    // Fill from the front (the largest number of rows) first.
+    for (var m = 0; m < remaining.length; /* mutating */)
+    {
+      var memberRows = rowKey[remaining[m][1]];
+      if (memberRows && (nextRows + memberRows < maxRows) && (queryLength + remaining[m][1].length < maxUIDStrLength))
+      {
+        var uid = String(remaining.splice(m, 1)[0][1]);
+        nextSet.push(uid);
+        nextRows += memberRows;
+        queryLength = nextSet.join(",").length;
+      }
+      else if (memberRows === 0)
+        remaining.splice(m, 1);
+      else
+        ++m;
+      // Stop searching if we can't add another member.
+      if (maxUIDStrLength - queryLength < 16)
+        break;
+    }
+    return nextSet;
+  }
+  /**
+   * Mutate the input records by determining the appropriate LastSeen and MHCC Crown values for each
+   * member's unique RankTime values. If a RankTime is duplicated, only the first instance is kept.
+   * 
+   * @param {Array[]} records    2D array destined to be uploaded to the Rank DB FusionTable.
+   * @param {{uid: {rankTimes: {String: Number}}}} dataMap Object which stores yet-unprocessed RankTimes, and the source row.
+   * @param {Array[]} reference  2D array downloaded from the Crown DB FusionTable, which birthed the records array.
+   * @return {void}
+   */
+  function _fillRankRecords_(records, dataMap, reference)
+  {
+    for (var r = 0; r < records.length; /* mutating */)
+    {
+      var record = records[r];
+      var rt = record[3], UID = String(record[1]);
+      // The RankTime will exist, unless we have used it already.
+      if (dataMap[UID].rankTimes[rt])
+      {
+        var desiredIndex = dataMap[UID].rankTimes[rt].row - 1;
+        if (desiredIndex >= 0 && String(reference[desiredIndex][1]) === UID)
+        {
+          var basisRow = reference[desiredIndex];
+          // We can use this row's data.
+          record[2] = basisRow[2];
+          record[5] = basisRow[4];
+          // Log the time shift (difference in LastTouched values) we've induced.
+          timeShifts.push(reference[desiredIndex + 1][3] - basisRow[3]);
+        }
+        else { /* Keep blank values for LastSeen and MHCC Crowns */ }
+
+        // We have used this RankTime value.
+        delete dataMap[UID].rankTimes[rt];
+        ++r;
+      }
+      // This is a duplicated value of RankTime for this member.
+      else
+        duplicates.push({ "uid": UID, "value": records.splice(r, 1) });
+    }
+  }
+
+  const start = new Date();
+
+  // Don't let Apps Script run this function concurrently.
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(30000))
+    return;
+
+  // Query both tables, to determine who is yet to be operated on.
+  const members = getUserBatch_(0, 10000),
+    done = _getRankTableUserIDs_(),
+    sizeData = getDbSizeData_();
+
+  // Filter the member list by those who have yet to be processed.
+  const toDo = members.filter(function (row) { return done.indexOf(String(row[1])) === -1; }),
+    rowKey = _getCrownTableRowCounts_(),
+    logs = [];
+
+  // We only need the Member Name, UID, LastSeen, LastTouched, MHCC Crowns, Rank, and RankTime.
+  const SELECT = ("SELECT Member, UID, LastSeen, LastTouched, MHCC, Rank, RankTime FROM " + ftid),
+    ORDER = ") ORDER BY UID ASC, RankTime ASC, LastTouched ASC";
+
+  do {
+    var uids = _getNextUserSet_(toDo, rowKey, 60000, 8000 - SELECT.length - ORDER.length - 15);
+    if (!uids || !uids.length) break;
+
+    console.time("Batch execution: " + uids.length + " members.");
+    var sql = SELECT + " WHERE UID IN (" + uids.join(",") + ORDER;
+    logs.push(sql);
+    // Download every record for these members from the MHCC Crowns DB, sorted ASC by RankTime & then LastTouched.
+    // The LastTouched value should be greater than the RankTime value for every record.
+    var crownRecords = FusionTables.Query.sqlGet(sql, { quotaUser: "maintenance" }).rows;
+    // Map between a given RankTime and the row it came from so that the previous row can be queried for
+    // LastSeen & MHCC Crown data, and we can remove duplicated RankTime values.
+    var rankMapping = {};
+    crownRecords.forEach(function (record, index) {
+      var UID = String(record[1]);
+      if (!rankMapping[UID]) rankMapping[UID] = { "rankTimes": {} };
+
+      // If this is a new RankTime, store it (& the row).
+      if (!rankMapping[UID].rankTimes[record[6]]) rankMapping[UID].rankTimes[record[6]] = { "row": index };
+    });
+
+    // Create the new Rank DB records from the bulk crown records, leaving LastSeen and MHCC Crown fields empty.
+    var rankRecords = crownRecords.map(function (record) {
+      //      Member   | UID      | LS         | RankTime | Rank     | MHCC Crowns.
+      return [record[0], record[1], /* blank */, record[6], record[5], /* blank */];
+    });
+
+    // Use the mapped information to fill in the rows as required.
+    var timeShifts = [], duplicates = [];
+    _fillRankRecords_(rankRecords, rankMapping, crownRecords);
+
+    // Upload the new rows to the Rank DB FusionTable.
+    if (rankRecords.length)
+      ftBatchWrite_(rankRecords, rankTableId, false);
+
+    console.timeEnd("Batch execution: " + uids.length + " members.");
+    console.log({ "numDuplicates": duplicates.length, "rowsAdded": rankRecords.length, "rowsDownloaded": crownRecords.length });
+    console.log({ "time shifts": timeShifts });
+  } while (toDo.length && (new Date() - start < 250 * 1000));
+
+  // Log a status report.
+  console.info({ "message": logs.length + " queries completed", "logs": logs, "timeUsed": (new Date() - start) / 1000, "# Remaining": toDo.length });
+
+  // Allow running this again.
+  lock.releaseLock();
+}
+/**
+ * Function which drops the given columns from the target table. Returns true only if all requested drops were complete.
+ * 
+ * @param {String} tableId
+ * @param {{matchOn:String, columns:any[]}} columnsToDrop An object which indicates what property of the columns should be matched, and the corresponding identifier to match.
+ *                                                     For example, matchOn could be 'name', and columns would contain the names of columns to drop.
+ * @return {Boolean}
+ */
+function columnDropper_(tableId, columnsToDrop)
+{
+  if (!tableId) tableId = ftid;
+  if (!columnsToDrop) columnsToDrop = { matchOn: "name", columns: ["Rank", "RankTime"] };
+
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(30 * 1000) || !columnsToDrop || !columnsToDrop.columns.length)
+    return;
+
+  // Make a backup of this table, but do *not* delete the previous one.
+  // If no backup is created (for example, FT storage quota is full), quit.
+  const backupID = doBackupTable_(tableId, false);
+  if (!backupID) return;
+
+  // Ensure a valid ID was given by attempting to read it.
+  const options = { quotaUser: "maintenance", "fields": "tableId,name,columns" };
+  try { var target = FusionTables.Table.get(tableId, options); }
+  catch (e) { console.error(e); return; }
+
+  // Check that the columns exist prior to removing them.
+  columnsToDrop.columns.forEach(function (col) {
+    if (target.columns.every(function (tc) { return tc[columnsToDrop.matchOn] !== col; }))
+      return;
+    try { FusionTables.Column.remove(target.tableId, col); }
+    catch (e) { console.error(e); }
+  });
+  lock.releaseLock();
+
+  // Report on the operational success by reading the new resource schema.
+  try { var alteredTable = FusionTables.Table.get(target.tableId, options); }
+  catch (e) { console.warn(e); }
+  const allCompleted = (target.columns.length - columnsToDrop.columns.length === alteredTable.columns.length);
+  console.log({ "message": "Column drop " + (allCompleted ? " successful." : " unsuccessful."), "original": target, "altered": alteredTable });
+  return allCompleted;
+}

--- a/mhcc/mhcc_updates_ft_interface.js
+++ b/mhcc/mhcc_updates_ft_interface.js
@@ -166,8 +166,7 @@ function ftBatchWrite_(newData, tableId, strict)
   catch (e)
   {
     e.message = "Unable to upload rows: " + e.message;
-    console.error(e);
-    if (tableId == ftid)
+    if (tableId == ftid && options.isStrict === true)
     {
       var badRows = newData.filter(function (record) { return record.length !== crownDBnumColumns; });
       if (badRows.length)

--- a/mhcc/mhcc_updates_ft_interface.js
+++ b/mhcc/mhcc_updates_ft_interface.js
@@ -141,35 +141,6 @@ function getLatestRows_()
 }
 
 /**
- * function getUserHistory_   Queries the crown data snapshots for the given user and returns crown
- *                            counts and rank data as a function of HT MostMice's LastSeen property.
- * @param  {String} UID       The UIDs of specific members for which the crown data snapshots are
- *                            returned. If multiple members are queried, use comma separators.
- * @param  {Boolean} blGroup  Optional parameter controlling GROUP BY or "return all" behavior.
- * @return {Object}           An object containing "user" (member's name), "headers", and "dataset".
- */
-function getUserHistory_(UID, blGroup)
-{
-  var sql = 'SELECT Member, LastSeen, Bronze, Silver, Gold, MHCC, Rank, ';
-  if (!UID)
-    throw new Error('No UID provided');
-  UID = String(UID);
-  if (blGroup == true)
-    sql += "MINIMUM(RankTime) FROM " + ftid + " WHERE UID IN (" + UID + ") GROUP BY Member, LastSeen, Bronze, Silver, Gold, MHCC, Rank ORDER BY LastSeen ASC";
-  else
-    sql += "RankTime FROM " + ftid + " WHERE UID IN (" + UID + ") ORDER BY LastSeen ASC";
-
-  var resp = FusionTables.Query.sqlGet(sql, {quotaUser: UID});
-  if (typeof resp.rows == 'undefined')
-    throw new Error('No data for UID=' + UID);
-
-  if (resp.rows.length > 0)
-    return {"user": resp.rows[resp.rows.length - 1][0], "headers": resp.columns, "dataset": resp.rows};
-  else
-    return "";
-}
-
-/**
  * function ftBatchWrite_     Convert the data array into a CSV blob and upload to FusionTables.
  * @param  {Array[]} newData  The 2D array of data that will be written to the database.
  * @param  {String}  tableId  The table to which the batch data should be written.

--- a/mhcc/mhcc_updates_ft_interface.js
+++ b/mhcc/mhcc_updates_ft_interface.js
@@ -339,7 +339,7 @@ function doBackupTable_(tableId, deleteEarliest)
   }
 
   if (!tableId) tableId = ftid;
-  if (!deleteEarliest) deleteEarliest = true;
+  if (deleteEarliest !== false) deleteEarliest = true;
 
   const uStore = PropertiesService.getUserProperties(),
     store = PropertiesService.getScriptProperties(),
@@ -367,16 +367,15 @@ function doBackupTable_(tableId, deleteEarliest)
   catch (e) { console.warn(e); }
 
   // Remove the oldest backup, if desired (and possible).
-  const newBackupKey = now.getTime();
   try
   {
     if (deleteEarliest && Object.keys(userBackup[tableId]).length > 1)
     {
       var earliest = Object.keys(userBackup[tableId]).reduce(function (dt, next) { return Math.min(dt * 1, next * 1); });
-      if (earliest != newBackupKey)
+      const key = String(earliest);
+      const idToDelete = userBackup[tableId][key];
+      if (idToDelete != tableId)
       {
-        const key = String(earliest);
-        const idToDelete = userBackup[tableId][key];
         FusionTables.Table.remove(idToDelete);
         delete userBackup[tableId][key];
         if (scriptBackup[tableId][key])
@@ -387,8 +386,9 @@ function doBackupTable_(tableId, deleteEarliest)
   catch (e) { console.warn(e); }
 
   // Store the data about the backup.
-  userBackup[tableId][String(newBackupKey)] = backup.tableId;
-  scriptBackup[tableId][String(newBackupKey)] = backup.tableId;
+  const newBackupKey = String(now.getTime());
+  userBackup[tableId][newBackupKey] = backup.tableId;
+  scriptBackup[tableId][newBackupKey] = backup.tableId;
   uStore.setProperty(userKey, JSON.stringify(userBackup));
   store.setProperty(scriptKey, JSON.stringify(scriptBackup));
   return backup.tableId;

--- a/mhcc/mhcc_updates_ss_ft.js
+++ b/mhcc/mhcc_updates_ss_ft.js
@@ -393,7 +393,7 @@ function UpdateScoreboard()
   var rankUpload = allHunters.map(function (record) {
     // Name, UID, LastSeen, RankTime, Rank, MHCC Crowns
     // [0],  [1], [2],      [10],     [11], [8]
-    return [record[0], record[1], record[2], record[10], record[11], record[8]];
+    return [record[0], String(record[1]), record[2], record[10], record[11], record[8]];
   });
   if (rankUpload.length && rankUpload[0].length === 6)
     ftBatchWrite_(rankUpload, rankTableId);

--- a/mhcc/mhcc_updates_ss_ft.js
+++ b/mhcc/mhcc_updates_ss_ft.js
@@ -43,7 +43,7 @@
  *  Click "Save" or press "Enter" to commit your change.
  */
 // @OnlyCurrentDoc
-var crownDBnumColumns = 12;
+var crownDBnumColumns = 10;
 // Change this number when additional rows containing special titles (like "Super Secret Squirrel") get added.
 // This only needs to change when rows are added - if values of existing rows are changed, all is well. :)
 var numCustomTitles = 16;
@@ -265,17 +265,14 @@ function UpdateDatabase()
             batchHunters[i][6] = nS                      // Silver
             batchHunters[i][7] = nG                      // Gold
             batchHunters[i][8] = nG-0 + nS-0;            // MHCC Crowns
-            batchHunters[i][9] = db[dbRow][9]            // The member's rank among all members
             // Determine the MHCC rank & Squirrel of this hunter.
             for (var k = 0; k < aRankTitle.length; ++k)
               if (batchHunters[i][8] >= aRankTitle[k][0])
               {
                 // Crown count meets/exceeds required crowns for this level.
-                batchHunters[i][10] = aRankTitle[k][2];
+                batchHunters[i][9] = aRankTitle[k][2];
                 break;
               }
-            // Store the time when this hunter's rank was determined.
-            batchHunters[i][11] = db[dbRow][11];  
           }
         }
         Array.prototype.push.apply(mem2Update, batchHunters);       // Stage this batch's data for a single write call

--- a/mhcc/webapp/fusiontable/code.js
+++ b/mhcc/webapp/fusiontable/code.js
@@ -1,30 +1,64 @@
 var ftid = "";
-var alt_table = "";
+var rankTableId = "";
 
 /**
- * function getUserHistory_   Queries the crown data snapshots for the given user and returns crown
- *                            counts and rank data as a function of HT MostMice's LastSeen property.
- * @param  {String} UID       The UIDs of specific members for which the crown data snapshots are
- *                            returned. If multiple members are queried, use comma separators.
- * @param  {Boolean} blGroup  Optional parameter controlling GROUP BY or "return all" behavior.
- * @return {Object}           An object containing "user" (member's name), "headers", and "dataset".
+ * Query the crown data snapshots for the given users to return crown counts and rank data.
+ * 
+ * @param  {String} uids                         The (comma-separated) UID string with specific members for whom the data snapshots are returned.
+ * @param  {Boolean} blGroup                     Optional parameter controlling GROUP BY or "return all" behavior. Generally true.
+ * @return {[{user:String, crown:{}, rank:{}}]}  An array of user data objects, each containing at minimum "user", "crown", and "rank".
  */
-function getUserHistory_(UID, blGroup)
+function getUserHistory_(uids, blGroup)
 {
-  var sql = 'SELECT Member, LastSeen, Bronze, Silver, Gold, MHCC, Rank, ';
-  if (!UID)
+  if (!uids)
     throw new Error('No UID provided');
+  uids = String(uids);
+
+  var labels = ["crown", "rank"];
+  var selects = [
+    "SELECT UID, Member, LastSeen, Bronze, Silver, Gold, MHCC FROM " + ftid,
+    "SELECT UID, Member, LastSeen, MHCC Crowns, Rank, RankTime FROM " + rankTableId
+  ];
+  var where = "WHERE UID IN (" + uids + ")";
+  var groups = [
+    "GROUP BY UID, Member, LastSeen, Bronze, Silver, Gold, MHCC",
+    "GROUP BY UID, Member, LastSeen, MHCC Crowns, Rank, RankTime"
+  ];
+  var orders = ["ORDER BY UID ASC, LastSeen ASC", "ORDER BY UID ASC, RankTime ASC"];
   
-  if (blGroup === true)
-    sql += "MINIMUM(RankTime) FROM " + ftid + " WHERE UID IN (" + UID.toString() + ") GROUP BY Member, LastSeen, Bronze, Silver, Gold, MHCC, Rank";
+  var sqls = [];
+  if (blGroup && selects.length === groups.length && groups.length === orders.length)
+  {
+    for (var i = 0, numClauses = selects.length; i < numClauses; ++i)
+      sqls.push([selects[i], where, groups[i], orders[i]].join(" "));
+  }
   else
-    sql += "RankTime FROM " + ftid + " WHERE UID IN (" + UID.toString() + ")";
+    selects.forEach(function (selectClause, i) { sqls.push([selectClause, where, orders[i]].join(" ")); });
 
-  sql += " ORDER BY LastSeen ASC";
-  var resp = FusionTables.Query.sqlGet(sql, {quotaUser: UID});
-  if (!resp || !resp.rows || !resp.rows.length)
-    throw new Error('No data for UID=' + UID);
+  var queryData = {};
+  sqls.forEach(function (sql, index) {
+    var resp = FusionTables.Query.sqlGet(sql, { quotaUser: uids });
+    if (!resp || !resp.rows || !resp.rows.length || !resp.columns)
+      throw new Error("No data for input=" + uids + " in the " + labels[index] + " datasource.");
 
-  // Use the most recent name for the user, since they may have changed it.
-  return {"user": resp.rows[resp.rows.length - 1][0], "headers": resp.columns, "dataset": resp.rows};
+    queryData[labels[index]] = { "headers": resp.columns, "dataset": resp.rows };
+  });
+  // Organize the query data by its associated member.
+  var members = uids.split(","), output = [];
+  members.forEach(function (id) {
+    var memberOutput = { "uid": id };
+    labels.forEach(function (l) {
+      var memberData = queryData[l].dataset.filter(function (row) { return row[0] === id; });
+      memberOutput[l] = {
+        "headers": queryData[l].headers,
+        // Do not include the member's UID in the column data sent to the webapp.
+        "dataset": memberData.map(function (row) { return row.slice(1); })
+      };
+    });
+    // Read the user's name from the last entry in the "crown" dataset (could query the Members FusionTable).
+    memberOutput.user = memberOutput["crown"].dataset.slice(-1)[0][0];
+    output.push(memberOutput);
+  });
+  
+  return output;
 }

--- a/mhcc/webapp/fusiontable/code.js
+++ b/mhcc/webapp/fusiontable/code.js
@@ -17,12 +17,12 @@ function getUserHistory_(uids, blGroup)
   var labels = ["crown", "rank"];
   var selects = [
     "SELECT UID, Member, LastSeen, Bronze, Silver, Gold, MHCC FROM " + ftid,
-    "SELECT UID, Member, LastSeen, MHCC Crowns, Rank, RankTime FROM " + rankTableId
+    "SELECT UID, Member, LastSeen, 'MHCC Crowns', Rank, RankTime FROM " + rankTableId
   ];
   var where = "WHERE UID IN (" + uids + ")";
   var groups = [
     "GROUP BY UID, Member, LastSeen, Bronze, Silver, Gold, MHCC",
-    "GROUP BY UID, Member, LastSeen, MHCC Crowns, Rank, RankTime"
+    "GROUP BY UID, Member, LastSeen, 'MHCC Crowns', Rank, RankTime"
   ];
   var orders = ["ORDER BY UID ASC, LastSeen ASC", "ORDER BY UID ASC, RankTime ASC"];
   
@@ -48,10 +48,10 @@ function getUserHistory_(uids, blGroup)
   members.forEach(function (id) {
     var memberOutput = { "uid": id };
     labels.forEach(function (l) {
-      var memberData = queryData[l].dataset.filter(function (row) { return row[0] === id; });
+      var memberData = queryData[l].dataset.filter(function (row) { return String(row[0]) === id; });
       memberOutput[l] = {
-        "headers": queryData[l].headers,
         // Do not include the member's UID in the column data sent to the webapp.
+        "headers": queryData[l].headers.slice(1),
         "dataset": memberData.map(function (row) { return row.slice(1); })
       };
     });

--- a/mhcc/webapp/webapp/js.html
+++ b/mhcc/webapp/webapp/js.html
@@ -52,16 +52,16 @@
         let xVals = {}, numSeries = dt[0].length - 1;
         for (let r = numHeaders, len = dt.length; r < len; ++r)
         {
-          let row = dt[r], xVal = row[0];
+          let row = dt[r], xVal = row[0].getTime();
           // Create this new xValue and give each Y-Column an array to push to.
           if (!xVals[xVal])
           {
             xVals[xVal] = {};
-            for (let c = 1; c < numSeries; ++c)
+            for (let c = 1; c <= numSeries; ++c)
               xVals[xVal][c] = [];
           }
           // Add this row's Y-Values to their respective arrays.
-          for (let c = 1; c < numSeries; ++c)
+          for (let c = 1; c <= numSeries; ++c)
             xVals[xVal][c].push(row[c]);
         }
         // Store this completed xValues map for this dataset at the same index level.
@@ -88,7 +88,7 @@
               if (Object.keys(xv[xVal]).length !== numColumns - 1)
                 throw new Error("Incorrect number of columns in datatable " + i + " for xVal " + xVal);
 
-              hasValues[i] = xv[xVal][0].length;
+              hasValues[i] = xv[xVal]['1'].length;
             }
             else
               hasValues[i] = 0;
@@ -99,7 +99,7 @@
           eachXV.forEach(function (xv, i) {
             unifiedX[xVal].values[i] = {};
             let numValues = hasValues[i];
-            for (let yCol = 1; yCol < numColumns - 1; ++yCol)
+            for (let yCol = 1; yCol < numColumns; ++yCol)
             {
               let inserted = 0;
               // Initialize the array for each data column.
@@ -122,7 +122,7 @@
         let dataSources = unifiedX[xVal].values;
         for (let r = 0; r < unifiedX[xVal].rows; ++r)
         {
-          let row = [xVal];
+          let row = [new Date(xVal * 1)];
           for (let dt in dataSources)
           {
             for (let yCol in dataSources[dt])
@@ -131,19 +131,20 @@
           newTable.push(row);
         }
       }
+      // Sort this new table chronologically ascending.
+      newTable.sort(function (a, b) { return a[0] - b[0]; });
 
       // Create the header row.
-      const headers = dataTables[0].slice(0, 1)[0],
-            headersToAdd = [];
+      const headers = dataTables[0].slice(0, 1)[0];
       for (let i = 1; i < dataTables.length; ++i)
-        Array.prototype.push.apply(headersToAdd, headers.slice(1));
+        Array.prototype.push.apply(headers, dataTables[i].slice(0, 1)[0].slice(1));
 
       if (newTable.length === 0)
         throw new Error("Failed to collate X data.");
-      if (newTable[0].length !== headersToAdd.length)
+      if (newTable[0].length !== headers.length)
         throw new Error("Header/Data column count mismatch");
 
-      newTable.unshift([headersToAdd]);
+      newTable.unshift(headers);
       return newTable;
     }
     /** All rank dataseries can be extracted to the same format, even if to be used for multi-member comparison.
@@ -152,7 +153,7 @@
     function _getRankDataSeries(userData)
     {
       return [].concat(
-        userData.rankHeader.slice(0, -1),
+        [userData.rankHeader[0].slice(0, -1)],
         userData.rankData.map(function (row) {
           //      RankTime          | Rank | Tooltip ( X crowns, rank: y, Seen: yyyy-mm-dd )
           return [new Date(row[0]), row[1], row[2] + " crowns:\nRank: " + row[1] + "\nSeen: " + new Date(row[3]).toLocaleDateString()];
@@ -236,7 +237,7 @@
      *        CrownHeader: [ LastSeen | Bronze | Silver | Gold | Total ]
      *        RankHeader:  [ RankTime | Rank | MHCC Crowns | LastSeen ]
      */
-    function _plotTwoUsers(dataInput)
+    function _plotMultipleUsers(dataInput)
     {
       // Google Charts requires a single column has all X data - series without Y data use `null` at the intersection.
       const crownDataSets = [], rankDataSets = [], names = [];
@@ -252,6 +253,8 @@
             })
         );
         let userRanks = _getRankDataSeries(userData);
+        // Overwrite the default series title ("Rank") with the member's name.
+        userRanks[0][1] = userData.memberName;
         // Store this detailed data for use in alternate plotting schema
         chartData[uid] = { crownHistory: userCrowns, rankHistory: userRanks };
         // Rank data keeps the same detail in both compare and normal plot modes.
@@ -284,6 +287,7 @@
           "title": titleStub + "Crowns",
           "pointSize": 4,
           "focusTarget": "category",
+          "interpolateNulls": true,
           "hAxis": { title: "Snapshot Date" },
           "vAxis": { title: "MHCC Crowns", minValue: 0 },
           "seriesType": "line",
@@ -306,8 +310,10 @@
         "options": {
           "title": titleStub + "Ranks",
           "pointSize": 5,
+          "focusTarget": "category",
+          "interpolateNulls": true,
           "hAxis": { title: "Ranking Date" },
-          "vAxis": { title: "Rank", direction: -1, minValue: 1, logScale: false },
+          "vAxis": { title: "MHCC Member Ranking", direction: -1, minValue: 1, logScale: false },
           "explorer": { axis: 'horizontal' }
         }
       });
@@ -320,10 +326,13 @@
       ['crownHistory', 'rankHistory'].forEach(function (id) { document.getElementById(id).innerHTML = m; });
       return;
     }
-    if (input.length === 1)
-      _plotOneUser(input);
-    else if (input.length === 2)
-      _plotTwoUsers(input);
+    // Data was sent as a JSONified string.
+    const data = JSON.parse(input);
+
+    if (Object.keys(data).length === 1)
+      _plotOneUser(data);
+    else if (Object.keys(data).length < 6)
+      _plotMultipleUsers(data);
     else
       return;
 
@@ -341,7 +350,7 @@
   });
   $(window).on('resizeEnd', drawAll);
   function drawAll() {
-    rhWrapper.draw();
-    chWrapper.draw();
+    if (rhWrapper) rhWrapper.draw();
+    if (chWrapper) chWrapper.draw();
   }
 </script>

--- a/mhcc/webapp/webapp/js.html
+++ b/mhcc/webapp/webapp/js.html
@@ -1,7 +1,7 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 <script type="text/javascript">
-  /*
+  /**
    * Once chart libraries load,
    *   Run the server-side function loadUserData()
    *   If the data loaded successfully, we run the client function "dataLoadedOK"
@@ -14,7 +14,7 @@
       .withFailureHandler(dataNotLoadedOK)
       .loadUserData(uid);
   };
-  /*
+  /**
    * Some error occurred while loading the user's crown and rank data. Based on the passed parameter
    * 'e', we could determine which had the error and attempt to reload it
    */
@@ -23,75 +23,310 @@
     document.getElementById('crownHistory').innerHTML = e.message;
     document.getElementById('rankHistory').innerHTML = "";
   }
-  /*
+  var rhWrapper, chWrapper, chartData = {};
+  /**
    * No error occurred while loading the crown and rank data. Use the passed data to plot
-   * @param {Object} input  an object with properties 'crownHistory','rankHistory', and memberName
+   * @param {{uid:{memberName: String, crownHeader:String[][], crownData: any[][], rankHeader:String[][], rankData: any[][]}}} input  a uid-indexed object
    */
-  var rhWrapper, chWrapper;
   function dataLoadedOK(input)
   {
+    /**
+     * Function which condenses the given 2D arrays into a single 2D array that can be plotted with Google Charts.
+     * I.e., any 2D array without an X value found in any of the other 2D arrays gets values of null in its y-data
+     * columns for those X-values, and common X-values have values from all 2D arrays.
+     * Returns an Mx(N-1)*K array for K input MxN arrays: [ X | 1.2 | ... | 1.N | 2.2 | ... | 2.N ... ] 
+     * 
+     * @param {any[][][]} dataTables  An array containing several 2D arrays with the same number of columns and headers.
+     * @param {Number} numHeaders     The number of header rows in each of the given dataTables.
+     */
+    function _collateX_(dataTables, numHeaders)
+    {
+      // Requre all input dataTables have the same number of data columns in every row.
+      const numColumns = dataTables[0][0].length;
+      if (!dataTables.every(function (dt) { return dt.every(function (r) { return r.length === numColumns; }); }))
+        throw new Error("Datatables cannot be merged due to different column counts.");
+
+      // Index all X-values of each input, and push each Y-value for each other Column (i.e. duplicates supported).
+      const allXVals = [];
+      dataTables.forEach(function (dt, index) {
+        let xVals = {}, numSeries = dt[0].length - 1;
+        for (let r = numHeaders, len = dt.length; r < len; ++r)
+        {
+          let row = dt[r], xVal = row[0];
+          // Create this new xValue and give each Y-Column an array to push to.
+          if (!xVals[xVal])
+          {
+            xVals[xVal] = {};
+            for (let c = 1; c < numSeries; ++c)
+              xVals[xVal][c] = [];
+          }
+          // Add this row's Y-Values to their respective arrays.
+          for (let c = 1; c < numSeries; ++c)
+            xVals[xVal][c].push(row[c]);
+        }
+        // Store this completed xValues map for this dataset at the same index level.
+        allXVals[index] = xVals;
+      });
+
+      // Beginning with the first datatable, import the xValues and add rows for each relevant Y-value.
+      const unifiedX = {}, numTables = dataTables.length;
+      allXVals.forEach(function (xData, index, eachXV) {
+        for (let xVal in xData)
+        {
+          // If this xValue already exists in the unified collection, then all series have been added for it.
+          if (unifiedX[xVal])
+            continue;
+          else
+            unifiedX[xVal] = { 'rows': 0, 'values': {} };
+
+          // Determine which dataTables have values to add (vs adding null), and how many.
+          let hasValues = {};
+          eachXV.forEach(function (xv, i) {
+            if (xv[xVal])
+            {
+              // Should be numColumns - 1 keys in xv[xVal].
+              if (Object.keys(xv[xVal]).length !== numColumns - 1)
+                throw new Error("Incorrect number of columns in datatable " + i + " for xVal " + xVal);
+
+              hasValues[i] = xv[xVal][0].length;
+            }
+            else
+              hasValues[i] = 0;
+            unifiedX[xVal].rows = Math.max(unifiedX[xVal].rows, hasValues[i]);
+          });
+
+          // The unified x-value data is an array with the values to insert for each column at that x-value for that dataset.
+          eachXV.forEach(function (xv, i) {
+            unifiedX[xVal].values[i] = {};
+            let numValues = hasValues[i];
+            for (let yCol = 1; yCol < numColumns - 1; ++yCol)
+            {
+              let inserted = 0;
+              // Initialize the array for each data column.
+              unifiedX[xVal].values[i][yCol] = [];
+              // Add as many real-valued datapoints as this dataTable has.
+              for (; inserted < numValues; ++inserted)
+                unifiedX[xVal].values[i][yCol].push(xv[xVal][yCol][inserted]);
+              // Add needed null-valued datapoints so that this dataTable has as many rows as all the other dataTables for this xValue.
+              for (; inserted < unifiedX[xVal].rows; ++inserted)
+                unifiedX[xVal].values[i][yCol].push(null);
+            }
+          });
+        }
+      });
+
+      // Now that the unified map is created, convert from the object to the needed Array.
+      const newTable = [];
+      for (let xVal in unifiedX)
+      {
+        let dataSources = unifiedX[xVal].values;
+        for (let r = 0; r < unifiedX[xVal].rows; ++r)
+        {
+          let row = [xVal];
+          for (let dt in dataSources)
+          {
+            for (let yCol in dataSources[dt])
+              row.push(dataSources[dt][yCol][r]);
+          }
+          newTable.push(row);
+        }
+      }
+
+      // Create the header row.
+      const headers = dataTables[0].slice(0, 1)[0],
+            headersToAdd = [];
+      for (let i = 1; i < dataTables.length; ++i)
+        Array.prototype.push.apply(headersToAdd, headers.slice(1));
+
+      if (newTable.length === 0)
+        throw new Error("Failed to collate X data.");
+      if (newTable[0].length !== headersToAdd.length)
+        throw new Error("Header/Data column count mismatch");
+
+      newTable.unshift([headersToAdd]);
+      return newTable;
+    }
+    /** All rank dataseries can be extracted to the same format, even if to be used for multi-member comparison.
+     * @return {any[][]}
+     */
+    function _getRankDataSeries(userData)
+    {
+      return [].concat(
+        userData.rankHeader.slice(0, -1),
+        userData.rankData.map(function (row) {
+          //      RankTime          | Rank | Tooltip ( X crowns, rank: y, Seen: yyyy-mm-dd )
+          return [new Date(row[0]), row[1], row[2] + " crowns:\nRank: " + row[1] + "\nSeen: " + new Date(row[3]).toLocaleDateString()];
+        })
+      );
+    }
+
+    /**
+     * Function which parses and displays the received user data for detailed inspection. Crown
+     * history will be plotted as several series.
+     * 
+     * @param {{uid:{memberName: String, crownHeader: String[][], crownData: any[][], rankHeader: String[][], rankData: any[][]}}} dataInput
+     *        Received data from the Apps Script server, containing plottable data for each given user id.
+     *        CrownHeader: [ LastSeen | Bronze | Silver | Gold | Total ]
+     *        RankHeader:  [ RankTime | Rank | MHCC Crowns | LastSeen ]
+     */
+    function _plotOneUser(dataInput)
+	  {
+      const uid = Object.keys(dataInput)[0];
+      const userData = dataInput[uid];
+      chartData[uid] = {};
+
+      // Crown History (Bronze as Line, Silver & Gold as stacked area, Total as Line
+		  chartData[uid].crownHistory = [].concat(
+			  userData.crownHeader,
+        userData.crownData.map(function (row) {
+          //       LastSeen       | Bronze | Silver | Gold | Total
+				  return [new Date(row[0]), row[1], row[2], row[3], row[4]];
+			  })
+		  );
+		  const crownDataTable = google.visualization.arrayToDataTable(chartData[uid].crownHistory, false);
+		  chWrapper = new google.visualization.ChartWrapper({
+			  "containerId": "crownHistory",
+			  "chartType": "ComboChart",
+			  "dataTable": crownDataTable,
+        "options": {
+          "title": String(userData.memberName + '\'s Crowns History'),
+          "pointSize": 4,
+          "focusTarget": "category",
+          "hAxis": { title: "Snapshot Date" },
+          "vAxis": { title: "Crown Counts", minValue: 0 },
+          "seriesType": "steppedArea",
+          "isStacked": true,
+          "series": { 0: { type: "line" }, 3: { type: "line" } },
+          "colors": ["brown", "silver", "gold", "black"],
+          "explorer": { axis: "horizontal" }
+        }
+		  });
+
+
+		  // Rank History (Rank 1 at top)
+		  chartData[uid].rankHistory = _getRankDataSeries(userData);
+		  const rankDataTable = google.visualization.arrayToDataTable(chartData[uid].rankHistory, false);
+		  rankDataTable.setColumnProperty(2, 'role', 'tooltip');
+		  const rankDelta = Math.abs(chartData[uid].rankHistory.slice(-1)[0][1] - chartData[uid].rankHistory[1][1]);
+		  if (rankDelta >= 1000)
+		  {
+			  rhOptions.vAxis.logScale = true;
+			  rhOptions.vAxis.minValue = Math.round(chartData[uid].rankHistory.slice(-1)[0][1] / 10);
+		  }
+		  rhWrapper = new google.visualization.ChartWrapper({
+			  "containerId": "rankHistory",
+			  "chartType": "LineChart",
+			  "dataTable": rankDataTable,
+        "options": {
+          "title": String(userData.memberName + '\'s MHCC Rank History'),
+          "pointSize": 5,
+          "hAxis": { title: "Ranking Date" },
+          "vAxis": { title: "Rank", direction: -1, minValue: 1, logScale: false },
+          "explorer": { axis: 'horizontal' }
+        }
+		  });
+	  }
+
+	  /**
+     * Function which parses and displays the received users' data for comparison. Crown
+     * history will be plotted as a comparison of users' MHCC Crowns.
+     * 
+     * @param {{uid:{memberName: String, crownHeader: String[][], crownData: any[][], rankHeader: String[][], rankData: any[][]}}} dataInput
+     *        Received data from the Apps Script server, containing plottable data for each given user id.
+     *        CrownHeader: [ LastSeen | Bronze | Silver | Gold | Total ]
+     *        RankHeader:  [ RankTime | Rank | MHCC Crowns | LastSeen ]
+     */
+    function _plotTwoUsers(dataInput)
+	  {
+      // Google Charts requires a single column has all X data - series without Y data use `null` at the intersection.
+      const crownDataSets = [], rankDataSets = [], names = [];
+      for (let uid in dataInput)
+      {
+        let userData = dataInput[uid];
+        names.push(userData.memberName);
+        let userCrowns = [].concat(
+            userData.crownHeader,
+            userData.crownData.map(function (row) {
+              //       LastSeen       | Bronze | Silver | Gold | Total
+              return [new Date(row[0]), row[1], row[2], row[3], row[4]];
+            })
+        );
+        let userRanks = _getRankDataSeries(userData);
+        // Store this detailed data for use in alternate plotting schema
+        chartData[uid] = { crownHistory: userCrowns, rankHistory: userRanks };
+        // Rank data keeps the same detail in both compare and normal plot modes.
+        rankDataSets.push(userRanks);
+        // Create a stripped detail version of the crown data for compare plot mode.
+        let userCrownCompare = userCrowns.map(function (row, index) {
+          return (index === 0 ? ["Last Seen", userData.memberName, "Tooltip"] :
+            [row[0], row[2] + row[3], "# Silver: " + row[2] + "\n# Gold: " + row[3]]);
+        });
+        chartData[uid].crownCompare = userCrownCompare;
+        crownDataSets.push(userCrownCompare);
+      }
+      // Union the input datasets
+      crownData = _collateX_(crownDataSets, 1);
+      rankData = _collateX_(rankDataSets, 1);
+      let titleStub = names.join(" vs. ") + ": ";
+
+      // Plot crown comparison.
+      const ccDataTable = google.visualization.arrayToDataTable(crownData, false);
+
+      // Set tooltip roles.
+      for (let c = 2; c < crownData[0].length; ++c) if ((c - 1) % 2 === 1)
+          ccDataTable.setColumnProperty(c, "role", "tooltip");
+
+      chWrapper = new google.visualization.ChartWrapper({
+        "containerId": "crownHistory",
+        "chartType": "LineChart",
+        "dataTable": ccDataTable,
+        "options": {
+          "title": titleStub + "Crowns",
+          "pointSize": 4,
+          "focusTarget": "category",
+          "hAxis": { title: "Snapshot Date" },
+          "vAxis": { title: "MHCC Crowns", minValue: 0 },
+          "seriesType": "line",
+          "explorer": { axis: "horizontal" }
+        }
+      });
+
+
+      // Plot rank comparison.
+      const rcDataTable = google.visualization.arrayToDataTable(rankData, false);
+
+      // Set tooltip roles.
+      for (let c = 2; c < rankData[0].length; ++c) if ((c - 1) % 2 === 1)
+          rcDataTable.setColumnProperty(c, "role", "tooltip");
+
+      rhWrapper = new google.visualization.ChartWrapper({
+        "containerId": "rankHistory",
+        "chartType": "LineChart",
+        "dataTable": rcDataTable,
+        "options": {
+          "title": titleStub + "Ranks",
+          "pointSize": 5,
+          "hAxis": { title: "Ranking Date" },
+          "vAxis": { title: "Rank", direction: -1, minValue: 1, logScale: false },
+          "explorer": { axis: 'horizontal' }
+        }
+      });
+	  }
+
+
     if (!input || !input.length)
-	{
-      console.log(input);
+	  {
+	    const m = "No data received from the Apps Script function";
+	    ['crownHistory', 'rankHistory'].forEach(function (id) { document.getElementById(id).innerHTML = m; });
       return;
     }
-    
-    // Crown History (Bronze as Line, Silver & Gold as stacked area, Total as Line
-    input.crownHistory = [].concat(
-	  input.crownHeader,
-	  input.crownData.map(function(value) {
-	    return [new Date(value[0]), value[1], value[2], value[3], value[4]];
-	  })
-	);
-    var ch = google.visualization.arrayToDataTable(input.crownHistory, false);
-    var chOptions = {
-      title: String(input.memberName + '\'s Crowns History'),
-      pointSize: 4,
-      focusTarget: 'category',
-      hAxis: {title: 'Snapshot Date'},
-      vAxis: {title: 'Crown Counts', minValue: 0},
-      seriesType: 'steppedArea',
-      isStacked: true,
-      series: {0: {type: 'line'}, 3: {type: 'line'}},
-      colors: ['brown','silver','gold','black'],
-      explorer: {axis: 'horizontal'}
-    };
-    chWrapper = new google.visualization.ChartWrapper({
-      containerId: 'crownHistory',
-      chartType: 'ComboChart',
-      dataTable: ch,
-      options: chOptions
-    });
-      
-    // Rank History (Rank 1 at top)
-    input.rankHistory = [].concat(
-	  input.rankHeader,
-	  input.rankData.map(function(value) {
-	    return [new Date(value[0]), value[1], value[2] + " crowns:\nRank: " + value[1]]
-      })
-	);
-	// First row is headers, cols of ranktime | rank | #mhcc
-    var rh = google.visualization.arrayToDataTable(input.rankHistory, false);
-    rh.setColumnProperty(2, 'role', 'tooltip');
-    var rhOptions = {
-      title: String(input.memberName + '\'s MHCC Rank History'),
-      pointSize: 5,
-      hAxis: {title: 'Ranking Date'},
-      vAxis: {title: 'Rank', direction: -1, minValue: 1, logScale: false},
-      explorer: {axis: 'horizontal'}
-    };
-    var rankDelta = Math.abs(input.rankHistory[input.rankHistory.length - 1][1] - input.rankHistory[1][1]);
-    if (rankDelta >= 1000) {
-      rhOptions.vAxis.logScale = true;
-      rhOptions.vAxis.minValue = Math.round(input.rankHistory[input.rankHistory.length - 1][1] / 10);
-    }
-    rhWrapper = new google.visualization.ChartWrapper({
-      containerId: 'rankHistory',
-      chartType: 'LineChart',
-      dataTable: rh,
-      options: rhOptions
-    });
-    
+	  if (input.length === 1)
+		  _plotOneUser(input);
+	  else if (input.length === 2)
+		  _plotTwoUsers(input);
+	  else
+		  return;
+
     drawAll();
   }
 

--- a/mhcc/webapp/webapp/js.html
+++ b/mhcc/webapp/webapp/js.html
@@ -170,24 +170,24 @@
      *        RankHeader:  [ RankTime | Rank | MHCC Crowns | LastSeen ]
      */
     function _plotOneUser(dataInput)
-	  {
+    {
       const uid = Object.keys(dataInput)[0];
       const userData = dataInput[uid];
       chartData[uid] = {};
 
       // Crown History (Bronze as Line, Silver & Gold as stacked area, Total as Line
-		  chartData[uid].crownHistory = [].concat(
-			  userData.crownHeader,
+      chartData[uid].crownHistory = [].concat(
+        userData.crownHeader,
         userData.crownData.map(function (row) {
           //       LastSeen       | Bronze | Silver | Gold | Total
-				  return [new Date(row[0]), row[1], row[2], row[3], row[4]];
-			  })
-		  );
-		  const crownDataTable = google.visualization.arrayToDataTable(chartData[uid].crownHistory, false);
-		  chWrapper = new google.visualization.ChartWrapper({
-			  "containerId": "crownHistory",
-			  "chartType": "ComboChart",
-			  "dataTable": crownDataTable,
+          return [new Date(row[0]), row[1], row[2], row[3], row[4]];
+        })
+      );
+      const crownDataTable = google.visualization.arrayToDataTable(chartData[uid].crownHistory, false);
+      chWrapper = new google.visualization.ChartWrapper({
+        "containerId": "crownHistory",
+        "chartType": "ComboChart",
+        "dataTable": crownDataTable,
         "options": {
           "title": String(userData.memberName + '\'s Crowns History'),
           "pointSize": 4,
@@ -200,23 +200,23 @@
           "colors": ["brown", "silver", "gold", "black"],
           "explorer": { axis: "horizontal" }
         }
-		  });
+      });
 
 
-		  // Rank History (Rank 1 at top)
-		  chartData[uid].rankHistory = _getRankDataSeries(userData);
-		  const rankDataTable = google.visualization.arrayToDataTable(chartData[uid].rankHistory, false);
-		  rankDataTable.setColumnProperty(2, 'role', 'tooltip');
-		  const rankDelta = Math.abs(chartData[uid].rankHistory.slice(-1)[0][1] - chartData[uid].rankHistory[1][1]);
-		  if (rankDelta >= 1000)
-		  {
-			  rhOptions.vAxis.logScale = true;
-			  rhOptions.vAxis.minValue = Math.round(chartData[uid].rankHistory.slice(-1)[0][1] / 10);
-		  }
-		  rhWrapper = new google.visualization.ChartWrapper({
-			  "containerId": "rankHistory",
-			  "chartType": "LineChart",
-			  "dataTable": rankDataTable,
+      // Rank History (Rank 1 at top)
+      chartData[uid].rankHistory = _getRankDataSeries(userData);
+      const rankDataTable = google.visualization.arrayToDataTable(chartData[uid].rankHistory, false);
+      rankDataTable.setColumnProperty(2, 'role', 'tooltip');
+      const rankDelta = Math.abs(chartData[uid].rankHistory.slice(-1)[0][1] - chartData[uid].rankHistory[1][1]);
+      if (rankDelta >= 1000)
+      {
+        rhOptions.vAxis.logScale = true;
+        rhOptions.vAxis.minValue = Math.round(chartData[uid].rankHistory.slice(-1)[0][1] / 10);
+      }
+      rhWrapper = new google.visualization.ChartWrapper({
+        "containerId": "rankHistory",
+        "chartType": "LineChart",
+        "dataTable": rankDataTable,
         "options": {
           "title": String(userData.memberName + '\'s MHCC Rank History'),
           "pointSize": 5,
@@ -224,10 +224,10 @@
           "vAxis": { title: "Rank", direction: -1, minValue: 1, logScale: false },
           "explorer": { axis: 'horizontal' }
         }
-		  });
-	  }
+      });
+    }
 
-	  /**
+    /**
      * Function which parses and displays the received users' data for comparison. Crown
      * history will be plotted as a comparison of users' MHCC Crowns.
      * 
@@ -237,7 +237,7 @@
      *        RankHeader:  [ RankTime | Rank | MHCC Crowns | LastSeen ]
      */
     function _plotTwoUsers(dataInput)
-	  {
+    {
       // Google Charts requires a single column has all X data - series without Y data use `null` at the intersection.
       const crownDataSets = [], rankDataSets = [], names = [];
       for (let uid in dataInput)
@@ -311,21 +311,21 @@
           "explorer": { axis: 'horizontal' }
         }
       });
-	  }
+    }
 
 
     if (!input || !input.length)
-	  {
-	    const m = "No data received from the Apps Script function";
-	    ['crownHistory', 'rankHistory'].forEach(function (id) { document.getElementById(id).innerHTML = m; });
+    {
+      const m = "No data received from the Apps Script function";
+      ['crownHistory', 'rankHistory'].forEach(function (id) { document.getElementById(id).innerHTML = m; });
       return;
     }
-	  if (input.length === 1)
-		  _plotOneUser(input);
-	  else if (input.length === 2)
-		  _plotTwoUsers(input);
-	  else
-		  return;
+    if (input.length === 1)
+      _plotOneUser(input);
+    else if (input.length === 2)
+      _plotTwoUsers(input);
+    else
+      return;
 
     drawAll();
   }

--- a/mhcc/webapp/webapp/server_code.js
+++ b/mhcc/webapp/webapp/server_code.js
@@ -31,11 +31,11 @@ function loadUserData(uids)
    * Nested function which handles parsing the data for a given user into the properly-formatted webapp code.
    * 
    * @param {{String:{}}} outputToModify
-   * @param {{name:String, crown:{}, rank:{}}} userData
+   * @param {{user:String, crown:{}, rank:{}}} userData
    */
   function _addUserData_(outputToModify, userData)
   {
-    var user = userData.name;
+    var user = userData.user;
     if (!user) throw new Error("Missing username for whom to parse data.");
     // Create a property for this user in the parent's collection object
     outputToModify[String(user)] = {};
@@ -45,7 +45,7 @@ function loadUserData(uids)
     /**
      * Format the FusionTables data for consumption by the webapp.
      * userData: {
-     *   "name": The user's display name
+     *   "user": The user's display name
      *   "crown": {
      *      "headers": [Member, LastSeen, Bronze, Silver, Gold, MHCC]
      *      "dataset": [][] ordered by LastSeen ascending
@@ -56,7 +56,7 @@ function loadUserData(uids)
      *   }
      * }
      */
-    userOutput.memberName = userData.name;
+    userOutput.memberName = user;
 
     userOutput.crownHeader = [["Date Seen", "# Bronze", "# Silver", "# Gold", "Total"]];
     var crownData = userData.crown.dataset.map(function (value) {
@@ -81,8 +81,8 @@ function loadUserData(uids)
   if (!uids || uids === "" || uids === "undefined")
     throw new Error("No UID provided/loaded");
   
-  if (uids.split(",").length > 2)
-    throw new Error("UI for comparing more than 2 members at once is not available.");
+  if (uids.split(",").length > 5)
+    throw new Error("UI for comparing that many members at once is not available.");
 
   // Obtain data for the UID(s).
   var history = getUserHistory_(uids, true),
@@ -94,5 +94,6 @@ function loadUserData(uids)
   if (Object.keys(dataForWebapp).length !== uids.split(",").length)
     console.warn({ message: "At least 1 requested dataset is unavailable", uids: uids.split(","), data: dataForWebapp });
 
-  return dataForWebapp;
+  // Due to object complexity, send as a string instead of a raw object.
+  return JSON.stringify(dataForWebapp);
 }

--- a/mhcc/webapp/webapp/server_code.js
+++ b/mhcc/webapp/webapp/server_code.js
@@ -1,64 +1,98 @@
-/*
+/**
  * Apps Script code to handle the webapp.
  * devlink (v):
  * publink (v):
  */
 
-/*
- * function doGet     Runs when the script's app link is clicked
- * @param {Object} e  Object containing various properties. Each link will have at least one parameter labeled uid
- *                    which is stored in e.parameter
- *                    {parameter={}, contextPath=, contentLength=-1, queryString=null, parameters={[]}}
- * @return {webpage}  Returns a webpage described by assembling the various .html files
+/**
+ * Runs when the script's app link is clicked
+ * 
+ * @param {{parameter: {String:String}, contextPath:String, contentLength:Number, queryString:null, parameters:{String:String[]}}} e
+ *                    Object containing various properties. Each link will have at least one parameter labeled "uid", stored in e.parameter
+ *                    Reference: https://developers.google.com/apps-script/guides/web#request_parameters
+ * @return {HtmlOutput}  Returns a webpage described by assembling the various .html files
  */
 function doGet(e)
 {
   var pg = HtmlService.createTemplateFromFile("webapp\\page");
+  // Require that multiple uids were explicitly joined, i.e. "&uid=1,2", rather than "&uid=1&uid=2".
   pg.webAppUID = e.parameter.uid;
   return pg.evaluate().setTitle("MHCC Crown History").setFaviconUrl("https://i.imgur.com/QMghA1l.png");
 }
-/*
- * function loadUserData    gets the crown and rank data from FusionTables for use by the webapp's plotters
- * @param {String} uid      The UID of the member to query
+/**
+ * Get the crown and rank data from FusionTables for use by the webapp's plotters.
+ * Due to limitations on transferable data, date values are sent as millisecond timestamps
+ * 
+ * @param {String} uids      The UID of the member to query
  */
-function loadUserData(uid)
+function loadUserData(uids)
 {
-  if (!uid || uid === "" || uid === "undefined")
+  /**
+   * Nested function which handles parsing the data for a given user into the properly-formatted webapp code.
+   * 
+   * @param {{String:{}}} outputToModify
+   * @param {{name:String, crown:{}, rank:{}}} userData
+   */
+  function _addUserData_(outputToModify, userData)
+  {
+    var user = userData.name;
+    if (!user) throw new Error("Missing username for whom to parse data.");
+    // Create a property for this user in the parent's collection object
+    outputToModify[String(user)] = {};
+    // Bind a reference to it.
+    const userOutput = outputToModify[String(user)];
+
+    /**
+     * Format the FusionTables data for consumption by the webapp.
+     * userData: {
+     *   "name": The user's display name
+     *   "crown": {
+     *      "headers": [Member, LastSeen, Bronze, Silver, Gold, MHCC]
+     *      "dataset": [][] ordered by LastSeen ascending
+     *   },
+     *   "rank": {
+     *      "headers": [Member, LastSeen, MHCC Crowns, Rank, RankTime]
+     *      "dataset": [][] ordered by RankTime ascending
+     *   }
+     * }
+     */
+    userOutput.memberName = userData.name;
+
+    userOutput.crownHeader = [["Date Seen", "# Bronze", "# Silver", "# Gold", "Total"]];
+    var crownData = userData.crown.dataset.map(function (value) {
+      return [value[1] * 1, value[2] * 1, value[3] * 1, value[4] * 1, (value[5] * 1 + value[2] * 1)];
+    });
+    // Ensure the data is sorted ascending by LastSeen.
+    userOutput.crownData = crownData.sort();
+
+    userOutput.rankHeader = [["Date Ranked", "Rank", "# MHCC Crowns", "Date Seen"]];
+    var rankData = userData.rank.dataset.map(function (value) {
+      return [value[4] * 1, value[3] * 1, value[2] * 1, value[1] * 1];
+    });
+    // Ensure the data is sorted ascending by RankTime.
+    userOutput.rankData = rankData.sort();
+
+    if (userOutput.crownHeader[0].length !== userOutput.crownData[0].length)
+      throw new Error("Crown History is not rectangular");
+    if (userOutput.rankHeader[0].length !== userOutput.rankData[0].length)
+      throw new Error("Rank History is not rectangular");
+  }
+
+  if (!uids || uids === "" || uids === "undefined")
     throw new Error("No UID provided/loaded");
   
-  switch (uid.split(",").length)
-  {
-    case 1:
-      var history = getUserHistory_(uid, true);
-      /* history = {"user":MemberName,
-      *            "headers":[Member, LastSeen, Bronze, Silver, Gold, MHCC, Rank, RankTime]
-      *            "dataset":[][] ordered by LastSeen ascending
-      *           }*/
-      // Split this object and format it for the webapp
-      var output = {};
-      output.memberName = history.user;
-      
-      var crownData = history.dataset.map(function(value, index) {
-        return [value[1] * 1, value[2] * 1, value[3] * 1, value[4] * 1, (value[5] * 1 + value[2] * 1)];
-      });
-      output.crownHeader = [["Date Seen", "# Bronze", "# Silver", "# Gold", "Total"]];
-      output.crownData = crownData.sort();
-      if (output.crownHeader[0].length !== output.crownData[0].length)
-        throw new Error("Crown History is not rectangular");
-      
-      var rankData = history.dataset.map(function(value, index) {
-        return [value[7] * 1, value[6] * 1, value[5] * 1];
-      });
-      output.rankHeader = [["Date Ranked", "Rank", "# MHCC Crowns"]];
-      output.rankData = rankData.sort();
-      if (output.rankHeader[0].length !== output.rankData[0].length)
-        throw new Error("Rank History is not rectangular");
-      
-      output.length = crownData.length;
-      break;
-    default:
-      throw new Error("Multi-member compare is not yet written");
-      break;
-  }
-  return output;
+  if (uids.split(",").length > 2)
+    throw new Error("UI for comparing more than 2 members at once is not available.");
+
+  // Obtain data for the UID(s).
+  var history = getUserHistory_(uids, true),
+      dataForWebapp = {};
+  history.forEach(function (user) { _addUserData_(dataForWebapp, user); });
+
+  if (!Object.keys(dataForWebapp).length)
+    throw new Error("No data to be sent to webapp");
+  if (Object.keys(dataForWebapp).length !== uids.split(",").length)
+    console.warn({ message: "At least 1 requested dataset is unavailable", uids: uids.split(","), data: dataForWebapp });
+
+  return dataForWebapp;
 }


### PR DESCRIPTION
 - Splits Rank, RankTime columns away from the Crown columns, since both are updated separately
  - Resolves issue when displaying Rank History where the crowns displayed for a given rank were measured after the member was ranked, resulting in nonsensical patterns (like a rank increase while crown count stays the same)
 - Ranks & RankTime now updated by UpdateScoreboard (which generates them)
 - UpdateDatabase only updates LastSeen/Crown/Touched, Squirrel, and crown values (as it generates this data)
  - LastCrown still measured by SheetDb (resolved with #13 )
 - Add multi-member comparison capability to the webapp (supply a CSV UID string to activate).
   - TODO: rework webapp to support post-load data querying, which would then let users change / add / remove members from the display without needing to reload the page, or know the member's UID.
 - More than one table backup is kept (which could cause issues with large tables - table growth is addressed in #13 )
 - Imported LastSeen are still subject to #10 : now have two tables to modify with corrections.

closes #11 